### PR TITLE
feat: export rules root path

### DIFF
--- a/KNOWLEDGE_BASE.md
+++ b/KNOWLEDGE_BASE.md
@@ -21,6 +21,7 @@
 - **Use**: `crs use <url|name>` - Configure or switch the active rules repository.
   - Supports auto-naming from URL.
   - Caches repositories locally.
+  - **Auto-configuration**: Detects `cursor-rules.json` in the repository root to configure behavior (e.g., `rootPath`).
 - **List**: `crs list` - Show configured repositories and the active one.
 - **Git Proxy**: `crs git <args...>` - Run git commands directly in the active rules repository context.
   - Supports `-t <repo>` to target specific repositories.
@@ -28,7 +29,8 @@
 ### 2. Rule Synchronization (`crs add`)
 - **Syntax**: `crs add <rule_name> [alias]`
 - **Functionality**:
-  - Links `repo/rules/<rule_name>` to `.cursor/rules/<alias>`.
+  - Links `<repo>/<rootPath>/<rule_name>` to `.cursor/rules/<alias>`.
+    - `rootPath` defaults to `rules`, can be customized by the rules repository via `cursor-rules.json`.
   - Updates `cursor-rules.json`.
   - Updates `.gitignore` to ignore the linked rule path.
 - **Options**:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ npm install -g cursor-rules-sync
 
 ## Create a new cursor rules git repository
 
-- `rules` folder is the root folder for cursor rules.
+- `rules` folder is the default root folder for cursor rules.
+- To use a different folder (e.g., `packages/rules`), add a `cursor-rules.json` file to the root of your repository:
+
+  ```json
+  {
+    "rootPath": "packages/rules"
+  }
+  ```
 
 ## Global Options
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -23,7 +23,14 @@ npm install -g cursor-rules-sync
 
 ## 创建新的 Cursor 规则 Git 仓库
 
-- `rules` 文件夹是存放 Cursor 规则的根目录。
+- `rules` 文件夹是默认的存放 Cursor 规则的根目录。
+- 也可以通过在仓库根目录添加 `cursor-rules.json` 文件来指定其他目录（例如 `packages/rules`）：
+
+  ```json
+  {
+    "rootPath": "packages/rules"
+  }
+  ```
 - 你可以在该目录下创建任意数量的规则文件夹。
 
 ## 全局选项

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "cursor-rules-sync",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-rules-sync",
+      "version": "0.2.0",
+      "license": "Unlicense",
       "dependencies": {
-        "@types/fs-extra": "^11.0.4",
-        "@types/node": "^25.0.3",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "execa": "^9.6.1",
@@ -17,6 +18,8 @@
         "crs": "dist/index.js"
       },
       "devDependencies": {
+        "@types/fs-extra": "^11.0.4",
+        "@types/node": "^25.0.3",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16"
       }
@@ -847,6 +850,7 @@
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
       "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/jsonfile": "*",
@@ -857,6 +861,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
       "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -866,6 +871,7 @@
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1621,6 +1627,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/src/link.ts
+++ b/src/link.ts
@@ -3,10 +3,16 @@ import path from 'path';
 import chalk from 'chalk';
 import { RepoConfig } from './config.js';
 import { addIgnoreEntry, removeIgnoreEntry } from './utils.js';
+import { getProjectConfig } from './project-config.js';
 
 export async function linkRule(projectPath: string, ruleName: string, repo: RepoConfig, alias?: string, isLocal: boolean = false) {
     const repoDir = repo.path;
-    const sourceRulePath = path.join(repoDir, 'rules', ruleName);
+
+    // Determine root path: repo internal config > default
+    const repoConfig = await getProjectConfig(repoDir);
+    const rootPath = repoConfig.rootPath || 'rules';
+
+    const sourceRulePath = path.join(repoDir, rootPath, ruleName);
 
     if (!await fs.pathExists(sourceRulePath)) {
         throw new Error(`Rule "${ruleName}" not found in repository "${repo.name}".`);

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -7,6 +7,7 @@ const LOCAL_CONFIG_FILENAME = 'cursor-rules.local.json';
 export interface ProjectConfig {
     rules?: Record<string, string | { url: string; rule?: string }>;
     // rules: key is the local alias (target name), value is repo url OR object with url and original rule name
+    rootPath?: string;
 }
 
 async function readConfigFile(filePath: string): Promise<ProjectConfig> {

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+import fs from 'fs-extra';
+import { linkRule } from '../src/link.js';
+import * as projectConfigModule from '../src/project-config.js';
+import * as utilsModule from '../src/utils.js';
+
+vi.mock('fs-extra');
+vi.mock('../src/project-config.js');
+vi.mock('../src/utils.js');
+
+describe('Link Module', () => {
+    const mockProjectPath = '/mock/project';
+    const mockRepo = {
+        name: 'test-repo',
+        url: 'http://test.git',
+        path: '/mock/repos/test-repo'
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(fs.pathExists).mockResolvedValue(true);
+        vi.mocked(fs.ensureDir).mockResolvedValue(undefined);
+        vi.mocked(fs.ensureSymlink).mockResolvedValue(undefined);
+        vi.mocked(fs.lstat).mockResolvedValue({ isSymbolicLink: () => true } as any);
+        vi.mocked(fs.remove).mockResolvedValue(undefined);
+        vi.mocked(utilsModule.addIgnoreEntry).mockResolvedValue(true);
+    });
+
+    it('should link rule using default rules directory', async () => {
+        // Mock getProjectConfig to return empty config (no rootPath)
+        vi.mocked(projectConfigModule.getProjectConfig).mockResolvedValue({});
+
+        await linkRule(mockProjectPath, 'my-rule', mockRepo);
+
+        const expectedSourcePath = path.join(mockRepo.path, 'rules', 'my-rule');
+        const expectedTargetPath = path.join(path.resolve(mockProjectPath), '.cursor', 'rules', 'my-rule');
+
+        expect(fs.ensureSymlink).toHaveBeenCalledWith(expectedSourcePath, expectedTargetPath);
+    });
+
+    it('should link rule using configured rootPath from repo config', async () => {
+        // Mock getProjectConfig to return config with rootPath
+        vi.mocked(projectConfigModule.getProjectConfig).mockResolvedValue({
+            rootPath: 'custom/rules/path'
+        });
+
+        await linkRule(mockProjectPath, 'my-rule', mockRepo);
+
+        const expectedSourcePath = path.join(mockRepo.path, 'custom/rules/path', 'my-rule');
+        const expectedTargetPath = path.join(path.resolve(mockProjectPath), '.cursor', 'rules', 'my-rule');
+
+        expect(fs.ensureSymlink).toHaveBeenCalledWith(expectedSourcePath, expectedTargetPath);
+    });
+
+    it('should throw error if source rule does not exist', async () => {
+        vi.mocked(projectConfigModule.getProjectConfig).mockResolvedValue({});
+        // Mock source path check to return false
+        vi.mocked(fs.pathExists).mockImplementation(async (p) => {
+            if (typeof p === 'string' && p.includes(mockRepo.path)) {
+                return false;
+            }
+            return true;
+        });
+
+        await expect(linkRule(mockProjectPath, 'missing-rule', mockRepo))
+            .rejects.toThrow('Rule "missing-rule" not found in repository "test-repo".');
+    });
+});
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces repo-configurable rules directory to make rule linking work outside the default `rules/` path.
> 
> - Update `link.ts` to read repo `cursor-rules.json` via `getProjectConfig` and use `rootPath` (defaulting to `rules`) when resolving source rules
> - Extend `ProjectConfig` with optional `rootPath` in `project-config.ts`
> - Add `tests/link.test.ts` covering default and custom `rootPath`, plus missing rule error
> - Refresh docs (`README.md`, `README_ZH.md`, `KNOWLEDGE_BASE.md`) to describe `rootPath` usage and auto-configuration
> - Bump package version to `0.2.0` and adjust dev dependency metadata in `package-lock.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92ab09fe233b2832607e99e4cb6fa7c0adf8771a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->