### PR TITLE
feat: add import command to reverse-import local rules into repository

### DIFF
--- a/KNOWLEDGE_BASE.md
+++ b/KNOWLEDGE_BASE.md
@@ -180,7 +180,38 @@ This eliminates the need for separate functions like `addCursorDependency`, `add
 - `ais claude install` - Install all Claude skills and agents.
 - `ais install` - Install everything.
 
-### 9. Configuration Files
+### 9. Import Entries to Rules Repository
+- **Purpose**: Reverse operation of `add` - imports existing local files/directories into the rules repository
+- **Syntax**:
+  - `ais import <name>` - Auto-detect tool and type
+  - `ais cursor import <name>` - Auto-detect subtype (rules/commands/skills)
+  - `ais cursor rules import <name>` - Explicit import of Cursor rule
+  - `ais cursor commands import <name>` - Explicit import of Cursor command
+  - `ais cursor skills import <name>` - Explicit import of Cursor skill
+  - `ais copilot import <name>` - Import Copilot instruction
+  - `ais claude skills import <name>` - Import Claude skill
+  - `ais claude agents import <name>` - Import Claude agent
+- **Options**:
+  - `--local` (`-l`) - Import as private rule (stores in `ai-rules-sync.local.json`)
+  - `--message <msg>` (`-m`) - Custom git commit message
+  - `--force` (`-f`) - Overwrite if entry already exists in repository
+  - `--push` (`-p`) - Automatically push to remote repository after commit
+- **Workflow**:
+  1. Verifies file/directory exists in project and is not already a symlink
+  2. Copies to rules repository
+  3. Git commits the changes (with optional custom message)
+  4. Optionally pushes to remote (with `--push` flag)
+  5. Deletes original from project
+  6. Creates symlink back to project (using existing `linkEntry` logic)
+  7. Adds to `ai-rules-sync.json` (or `.local.json` with `--local`)
+- **Implementation**: Uses `importEntry()` function in `src/sync-engine.ts` with `ImportOptions` interface extending `SyncOptions`
+- **Error Handling**:
+  - Entry not found in project → Error
+  - Entry is already a symlink → Error (already managed)
+  - Entry exists in repository without `--force` → Error
+  - After import, entry is managed like any other synced rule
+
+### 10. Configuration Files
 
 **Rules Repository Config** (`ai-rules-sync.json` in the rules repo):
 ```json

--- a/README.md
+++ b/README.md
@@ -237,6 +237,67 @@ ais claude agents remove [alias]
 
 This command removes the symbolic link, the ignore entry, and the dependency from `ai-rules-sync.json` (or `ai-rules-sync.local.json`).
 
+### Import entries to rules repository
+
+The `import` command allows you to take existing rules/skills/commands from your project and import them into your rules repository. This is useful when you've created rules locally and want to centralize them.
+
+**How it works:**
+1. Copies the file/directory from your project to the rules repository
+2. Commits the changes to the rules repository
+3. Deletes the original file/directory from your project
+4. Creates a symbolic link back (just like `add`)
+
+**Basic usage:**
+
+```bash
+# Auto-detect tool and type
+ais import my-custom-rule
+
+# Specify tool (auto-detects rules/commands/skills)
+ais cursor import my-custom-rule
+
+# Explicitly specify everything
+ais cursor rules import my-custom-rule
+ais cursor commands import format-code.md
+ais cursor skills import code-review
+ais copilot import test-guide
+ais claude skills import analyzer
+ais claude agents import debugger
+```
+
+**Flags:**
+
+- `-l, --local`: Import as private rule (stores in `ai-rules-sync.local.json`)
+- `-m, --message <msg>`: Custom git commit message
+- `-f, --force`: Overwrite if entry already exists in repository
+- `-p, --push`: Automatically push to remote repository after commit
+
+**Examples:**
+
+```bash
+# Import with custom commit message
+ais cursor rules import my-rule -m "Add custom authentication rule"
+
+# Import as private rule
+ais cursor rules import private-rule --local
+
+# Force overwrite existing entry and push to remote
+ais cursor rules import my-rule --force --push
+
+# Import Copilot instruction
+ais copilot import test-guide
+
+# Import Claude skill
+ais claude skills import code-review
+```
+
+**Error handling:**
+
+- If the entry doesn't exist in your project, you'll get an error
+- If the entry is already a symlink (managed by ais), it won't be imported
+- If the entry exists in the repository without `--force`, import will fail
+- After import, the entry is managed like any other synced rule
+
 ### ai-rules-sync.json structure
 
 The `ai-rules-sync.json` file stores Cursor rules, commands, and Copilot instructions separately. It supports both simple string values (repo URL) and object values for aliased entries.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -264,6 +264,67 @@ ais claude agents remove [alias]
 
 该命令会删除软链接、ignore 文件中的条目，并从 `ai-rules-sync.json`（或 `ai-rules-sync.local.json`）中移除依赖。
 
+### 导入条目到规则仓库
+
+`import` 命令允许你将项目中已有的规则/技能/命令导入到规则仓库中。当你在本地创建了规则并希望集中管理时，这个功能非常有用。
+
+**工作原理：**
+1. 将文件/目录从项目复制到规则仓库
+2. 在规则仓库中提交更改
+3. 删除项目中的原始文件/目录
+4. 创建软链接链回项目（就像 `add` 命令一样）
+
+**基本用法：**
+
+```bash
+# 自动检测工具和类型
+ais import my-custom-rule
+
+# 指定工具（自动检测 rules/commands/skills）
+ais cursor import my-custom-rule
+
+# 明确指定所有内容
+ais cursor rules import my-custom-rule
+ais cursor commands import format-code.md
+ais cursor skills import code-review
+ais copilot import test-guide
+ais claude skills import analyzer
+ais claude agents import debugger
+```
+
+**可用标志：**
+
+- `-l, --local`: 导入为私有规则（存储在 `ai-rules-sync.local.json`）
+- `-m, --message <msg>`: 自定义 git 提交消息
+- `-f, --force`: 强制覆盖仓库中的现有条目
+- `-p, --push`: 提交后自动推送到远程仓库
+
+**示例：**
+
+```bash
+# 使用自定义提交消息导入
+ais cursor rules import my-rule -m "添加自定义身份验证规则"
+
+# 导入为私有规则
+ais cursor rules import private-rule --local
+
+# 强制覆盖现有条目并推送到远程
+ais cursor rules import my-rule --force --push
+
+# 导入 Copilot 指令
+ais copilot import test-guide
+
+# 导入 Claude 技能
+ais claude skills import code-review
+```
+
+**错误处理：**
+
+- 如果项目中不存在该条目，会显示错误
+- 如果该条目已经是软链接（由 ais 管理），不会被导入
+- 如果仓库中已存在该条目且未使用 `--force`，导入会失败
+- 导入后，该条目将像其他同步的规则一样被管理
+
 ### ai-rules-sync.json 结构
 
 `ai-rules-sync.json` 文件用于分别记录 Cursor 规则、命令、技能、Copilot 指令和 Claude 技能/代理。它支持简单的字符串格式（仅 URL）和对象格式（包含 URL 和原名）。

--- a/src/sync-engine.ts
+++ b/src/sync-engine.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
+import { execa } from 'execa';
 import { RepoConfig } from './config.js';
 import { SyncAdapter, LinkResult, SyncOptions } from './adapters/types.js';
 import { addIgnoreEntry, removeIgnoreEntry } from './utils.js';
@@ -154,4 +155,86 @@ async function handleIgnoreEntry(
             console.log(chalk.gray(`"${entry}" already in ${fileName}.`));
         }
     }
+}
+
+/**
+ * Import options extending SyncOptions
+ */
+export interface ImportOptions extends SyncOptions {
+    commitMessage?: string;
+    force?: boolean;
+    push?: boolean;
+}
+
+/**
+ * Import an entry from project to rules repository
+ * This is the reverse operation of link - it copies local files to the repo,
+ * commits them, removes the originals, and creates symlinks back.
+ */
+export async function importEntry(
+    adapter: SyncAdapter,
+    options: ImportOptions
+): Promise<{ imported: boolean; sourceName: string; targetName: string }> {
+    const { projectPath, name, repo, force = false, push = false, commitMessage } = options;
+
+    // 1. Check if entry exists in project
+    const absoluteProjectPath = path.resolve(projectPath);
+    const targetDir = path.join(absoluteProjectPath, adapter.targetDir);
+    const targetPath = path.join(targetDir, name);
+
+    if (!await fs.pathExists(targetPath)) {
+        throw new Error(`Entry "${name}" not found in project at ${targetPath}`);
+    }
+
+    // 2. Check if it's already a symlink (already managed)
+    const stats = await fs.lstat(targetPath);
+    if (stats.isSymbolicLink()) {
+        throw new Error(`Entry "${name}" is already a symlink (already managed by ai-rules-sync)`);
+    }
+
+    // 3. Determine destination in rules repository
+    const repoDir = repo.path;
+    const repoConfig = await getRepoSourceConfig(repoDir);
+    const sourceDir = getSourceDir(repoConfig, adapter.tool, adapter.subtype, adapter.defaultSourceDir);
+    const destPath = path.join(repoDir, sourceDir, name);
+
+    // 4. Check if destination already exists
+    if (await fs.pathExists(destPath)) {
+        if (!force) {
+            throw new Error(`Entry "${name}" already exists in rules repository at ${destPath}. Use --force to overwrite.`);
+        }
+        console.log(chalk.yellow(`Entry "${name}" already exists in repository. Overwriting (--force)...`));
+        await fs.remove(destPath);
+    }
+
+    // 5. Copy to rules repository
+    await fs.copy(targetPath, destPath);
+    console.log(chalk.green(`Copied "${name}" to rules repository.`));
+
+    // 6. Git add and commit
+    const relativePath = path.relative(repoDir, destPath);
+    await execa('git', ['add', relativePath], { cwd: repoDir });
+    const message = commitMessage || `Import ${adapter.tool} ${adapter.subtype}: ${name}`;
+    await execa('git', ['commit', '-m', message], { cwd: repoDir, stdio: 'inherit' });
+    console.log(chalk.green(`Committed to rules repository.`));
+
+    // 7. Push to remote if --push flag is set
+    if (push) {
+        console.log(chalk.gray('Pushing to remote repository...'));
+        await execa('git', ['push'], { cwd: repoDir, stdio: 'inherit' });
+        console.log(chalk.green(`Pushed to remote repository.`));
+    }
+
+    // 8. Remove original from project
+    await fs.remove(targetPath);
+    console.log(chalk.green(`Removed original from project.`));
+
+    // 9. Create symlink using existing link functionality
+    const linkResult = await linkEntry(adapter, options);
+
+    return {
+        imported: true,
+        sourceName: linkResult.sourceName,
+        targetName: linkResult.targetName
+    };
 }

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -123,10 +123,9 @@ describe('Completion Module', () => {
       expect(result).toContain(completionModule.COMPLETION_END_MARKER);
     });
 
-    it('should return file-based snippet for zsh with block markers', () => {
+    it('should return eval-style snippet for zsh with block markers', () => {
       const result = completionModule.getCompletionSnippet('zsh');
-      expect(result).toContain('ais completion > ~/.zsh/ais_completion.zsh');
-      expect(result).toContain('source ~/.zsh/ais_completion.zsh');
+      expect(result).toContain('eval "$(ais completion zsh)"');
       expect(result).toContain(completionModule.COMPLETION_START_MARKER);
       expect(result).toContain(completionModule.COMPLETION_END_MARKER);
     });


### PR DESCRIPTION
Implements `ais import` command that allows users to import existing local rules/skills/commands into the centralized rules repository.

Key features:
- Supports all tool types (Cursor, Copilot, Claude)
- Auto-detection and explicit specification modes
- Copies files to repository, commits changes, and creates symlinks
- Flags: --local, --message, --force, --push
- 8 command variants for different tools and subtypes

Implementation:
- Added `importEntry()` function in sync-engine.ts
- Added `ImportOptions` interface extending SyncOptions
- Added import commands for all adapters in index.ts
- Updated documentation (README.md, README_ZH.md, KNOWLEDGE_BASE.md)
- Fixed completion test to match current zsh implementation